### PR TITLE
Implement direct java call (which makes using perf etc. easier)

### DIFF
--- a/common-functions.sh
+++ b/common-functions.sh
@@ -271,4 +271,16 @@ if [ -z $DEBUG ]; then
 	DEBUG=false		## false
 fi
 
+
+# These technical configuration parameters should only be changed under exceptional circumstances
+if [ -z $APP_HOME ]
+then
+	APP_HOME=../../benchmark
+fi
+
+if [ -z $CLASSPATH ]
+then
+	CLASSPATH=$APP_HOME/lib/benchmark.jar:$APP_HOME/lib/jcommander-1.72.jar
+fi
+
 # end

--- a/frameworks/Kieker-java/functions.sh
+++ b/frameworks/Kieker-java/functions.sh
@@ -53,7 +53,9 @@ function executeExperiment() {
     RESULT_FILE="${RAWFN}-${loop}-${recursion}-${index}.csv"
     LOG_FILE="${RESULTS_DIR}/output_${loop}_${RECURSION_DEPTH}_${index}.txt"
 
-    "${MOOBENCH_BIN}" \
+    java $DEFAULT_JVM_OPTS $JAVA_OPTS $BENCHMARK_OPTS \
+        -cp $CLASSPATH \
+        moobench.benchmark.BenchmarkMain \
 	--application moobench.application.MonitoredClassSimple \
         --output-filename "${RESULT_FILE}" \
         --total-calls "${TOTAL_NUM_OF_CALLS}" \

--- a/frameworks/OpenTelemetry-java/functions.sh
+++ b/frameworks/OpenTelemetry-java/functions.sh
@@ -45,7 +45,10 @@ function runNoInstrumentation {
     info " # ${i}.$RECURSION_DEPTH.${k} ${TITLE[$k]}"
     echo " # ${i}.$RECURSION_DEPTH.${k} ${TITLE[$k]}" >> "${BASE_DIR}/OpenTelemetry.log"
     export BENCHMARK_OPTS="${JAVA_ARGS_NOINSTR}"
-    "${MOOBENCH_BIN}" --output-filename "${RAWFN}-${i}-$RECURSION_DEPTH-${k}.csv" \
+    java $DEFAULT_JVM_OPTS $JAVA_OPTS $BENCHMARK_OPTS \
+        -cp $CLASSPATH \
+        moobench.benchmark.BenchmarkMain \
+        --output-filename "${RAWFN}-${i}-$RECURSION_DEPTH-${k}.csv" \
         --total-calls "${TOTAL_NUM_OF_CALLS}" \
         --method-time "${METHOD_TIME}" \
         --total-threads "${THREADS}" \
@@ -59,7 +62,10 @@ function runOpenTelemetryNoLogging {
     info " # ${i}.$RECURSION_DEPTH.${k} "${TITLE[$k]}
     echo " # ${i}.$RECURSION_DEPTH.${k} "${TITLE[$k]} >> "${BASE_DIR}/OpenTelemetry.log"
     export BENCHMARK_OPTS="${JAVA_ARGS_OPENTELEMETRY_LOGGING_DEACTIVATED}"
-    "${MOOBENCH_BIN}" --output-filename "${RAWFN}-${i}-$RECURSION_DEPTH-${k}.csv" \
+    java $DEFAULT_JVM_OPTS $JAVA_OPTS $BENCHMARK_OPTS \
+        -cp $CLASSPATH \
+        moobench.benchmark.BenchmarkMain \
+        --output-filename "${RAWFN}-${i}-$RECURSION_DEPTH-${k}.csv" \
         --total-calls "${TOTAL_NUM_OF_CALLS}" \
         --method-time "${METHOD_TIME}" \
         --total-threads "${THREADS}" \
@@ -73,7 +79,10 @@ function runOpenTelemetryLogging {
     info " # ${i}.$RECURSION_DEPTH.${k} ${TITLE[$k]}"
     echo " # ${i}.$RECURSION_DEPTH.${k} ${TITLE[$k]}" >> "${BASE_DIR}/OpenTelemetry.log"
     export BENCHMARK_OPTS="${JAVA_ARGS_OPENTELEMETRY_LOGGING}"
-    "${MOOBENCH_BIN}" --output-filename "${RAWFN}-${i}-${RECURSION_DEPTH}-${k}.csv" \
+    java $DEFAULT_JVM_OPTS $JAVA_OPTS $BENCHMARK_OPTS \
+        -cp $CLASSPATH \
+        moobench.benchmark.BenchmarkMain \
+        --output-filename "${RAWFN}-${i}-${RECURSION_DEPTH}-${k}.csv" \
         --total-calls "${TOTAL_NUM_OF_CALLS}" \
         --method-time "${METHOD_TIME}" \
         --total-threads "${THREADS}" \
@@ -111,7 +120,10 @@ function runOpenTelemetryJaeger {
     info " # ${i}.$RECURSION_DEPTH.${k} ${TITLE[$k]}"
     echo " # ${i}.$RECURSION_DEPTH.${k} ${TITLE[$k]}" >> "${BASE_DIR}/OpenTelemetry.log"
     export BENCHMARK_OPTS="${JAVA_ARGS_OPENTELEMETRY_JAEGER}"
-    "${MOOBENCH_BIN}" --output-filename "${RAWFN}-${i}-${RECURSION_DEPTH}-${k}.csv" \
+    java $DEFAULT_JVM_OPTS $JAVA_OPTS $BENCHMARK_OPTS \
+        -cp $CLASSPATH \
+        moobench.benchmark.BenchmarkMain \
+        --output-filename "${RAWFN}-${i}-${RECURSION_DEPTH}-${k}.csv" \
         --total-calls "${TOTAL_NUM_OF_CALLS}" \
         --method-time "${METHOD_TIME}" \
         --total-threads "${THREADS}" \
@@ -128,7 +140,10 @@ function runOpenTelemetryPrometheus {
     info " # ${i}.$RECURSION_DEPTH.${k} ${TITLE[$k]}"
     echo " # ${i}.$RECURSION_DEPTH.${k} ${TITLE[$k]}" >> "${BASE_DIR}/OpenTelemetry.log"
     export BENCHMARK_OPTS="${JAVA_ARGS_OPENTELEMETRY_PROMETHEUS}"
-    "${MOOBENCH_BIN}" --output-filename "${RAWFN}-${i}-${RECURSION_DEPTH}-${k}.csv" \
+    java $DEFAULT_JVM_OPTS $JAVA_OPTS $BENCHMARK_OPTS \
+        -cp $CLASSPATH \
+        moobench.benchmark.BenchmarkMain \
+        --output-filename "${RAWFN}-${i}-${RECURSION_DEPTH}-${k}.csv" \
         --total-calls "${TOTAL_NUM_OF_CALLS}" \
         --method-time "${METHOD_TIME}" \
         --total-threads "${THREADS}" \

--- a/frameworks/inspectIT-java/functions.sh
+++ b/frameworks/inspectIT-java/functions.sh
@@ -37,7 +37,10 @@ function runNoInstrumentation {
     info " # ${i}.$RECURSION_DEPTH.${k} ${TITLE[$k]}"
     echo " # ${i}.$RECURSION_DEPTH.${k} ${TITLE[$k]}" >> "${BASE_DIR}/inspectIT.log"
     export BENCHMARK_OPTS="${JAVA_ARGS_NOINSTR}"
-    "${MOOBENCH_BIN}" --output-filename "${RAWFN}-${i}-$RECURSION_DEPTH-${k}.csv" \
+    java $DEFAULT_JVM_OPTS $JAVA_OPTS $BENCHMARK_OPTS \
+        -cp $CLASSPATH \
+        moobench.benchmark.BenchmarkMain \
+        --output-filename "${RAWFN}-${i}-$RECURSION_DEPTH-${k}.csv" \
         --total-calls "${TOTAL_NUM_OF_CALLS}" \
         --method-time "${METHOD_TIME}" \
         --total-threads "${THREADS}" \
@@ -51,7 +54,10 @@ function runInspectITDeactivated {
     echo " # ${i}.$RECURSION_DEPTH.${k} "${TITLE[$k]} >> "${BASE_DIR}/inspectIT.log"
     sleep "${SLEEP_TIME}"
     export BENCHMARK_OPTS="${JAVA_ARGS_INSPECTIT_DEACTIVATED}"
-    "${MOOBENCH_BIN}" --output-filename "${RAWFN}-${i}-$RECURSION_DEPTH-${k}.csv" \
+    java $DEFAULT_JVM_OPTS $JAVA_OPTS $BENCHMARK_OPTS \
+        -cp $CLASSPATH \
+        moobench.benchmark.BenchmarkMain \
+         --output-filename "${RAWFN}-${i}-$RECURSION_DEPTH-${k}.csv" \
         --total-calls "${TOTAL_NUM_OF_CALLS}" \
         --method-time "${METHOD_TIME}" \
         --total-threads "${THREADS}" \
@@ -67,7 +73,10 @@ function runInspectITNullWriter {
     echo " # ${i}.$RECURSION_DEPTH.${k} "${TITLE[$k]} >>${BASE_DIR}/inspectIT.log
     sleep "${SLEEP_TIME}"
     export BENCHMARK_OPTS="${JAVA_ARGS_INSPECTIT_NULLWRITER}"
-    "${MOOBENCH_BIN}" --output-filename "${RAWFN}-${i}-${RECURSION_DEPTH}-${k}.csv" \
+    java $DEFAULT_JVM_OPTS $JAVA_OPTS $BENCHMARK_OPTS \
+        -cp $CLASSPATH \
+        moobench.benchmark.BenchmarkMain \
+        --output-filename "${RAWFN}-${i}-${RECURSION_DEPTH}-${k}.csv" \
         --total-calls "${TOTAL_NUM_OF_CALLS}" \
         --method-time "${METHOD_TIME}" \
         --total-threads "${THREADS}" \
@@ -86,7 +95,10 @@ function runInspectITZipkin {
     startZipkin
     sleep "${SLEEP_TIME}"
     export BENCHMARK_OPTS="${JAVA_ARGS_INSPECTIT_ZIPKIN}"
-    "${MOOBENCH_BIN}" --output-filename "${RAWFN}-${i}-${RECURSION_DEPTH}-${k}.csv" \
+    java $DEFAULT_JVM_OPTS $JAVA_OPTS $BENCHMARK_OPTS \
+        -cp $CLASSPATH \
+        moobench.benchmark.BenchmarkMain \
+        --output-filename "${RAWFN}-${i}-${RECURSION_DEPTH}-${k}.csv" \
         --total-calls "${TOTAL_NUM_OF_CALLS}" \
         --method-time "${METHOD_TIME}" \
         --total-threads "${THREADS}" \
@@ -105,7 +117,10 @@ function runInspectITPrometheus {
     startPrometheus
     sleep "${SLEEP_TIME}"
     export BENCHMARK_OPTS="${JAVA_ARGS_INSPECTIT_PROMETHEUS}"
-    "${MOOBENCH_BIN}" --output-filename "${RAWFN}-${i}-${RECURSION_DEPTH}-${k}.csv" \
+    java $DEFAULT_JVM_OPTS $JAVA_OPTS $BENCHMARK_OPTS \
+        -cp $CLASSPATH \
+        moobench.benchmark.BenchmarkMain \
+        --output-filename "${RAWFN}-${i}-${RECURSION_DEPTH}-${k}.csv" \
         --total-calls "${TOTAL_NUM_OF_CALLS}" \
         --method-time "${METHOD_TIME}" \
         --total-threads "${THREADS}" \


### PR DESCRIPTION
Currently, the `java` call of MooBench is built via the shell script, that is generated by the Gradle application plugin. This is a little bit hard to understand, and makes manual experimentation, e.g. with `perf`, harder. Therefore, I propose to replace this by direct `java` calls and configuring them inside the `common-functions.sh`. 

It would also be possible to call the fat jar with `java -jar tools/benchmark/build/libs/benchmark.jar` instead of using `-cp`.