### PR TITLE
Fixes for the Kieker-python benchmark

### DIFF
--- a/frameworks/Kieker-python/benchmark.sh
+++ b/frameworks/Kieker-python/benchmark.sh
@@ -5,6 +5,10 @@
 #
 # Usage: benchmark.sh
 
+VENV_DIR="${HOME}/venv/moobench"
+python3 -m venv ${VENV_DIR}
+source ${VENV_DIR}/bin/activate
+
 # configure base dir
 BASE_DIR=$(cd "$(dirname "$0")"; pwd)
 
@@ -157,6 +161,9 @@ checkFile results.yaml "${RESULTS_DIR}/results.yaml"
 checkFile results.yaml "${RESULTS_DIR}/results.zip"
 
 info "Done."
+
+deactivate
+rm -rf ${VENV_DIR}
 
 exit 0
 # end

--- a/frameworks/Kieker-python/functions.sh
+++ b/frameworks/Kieker-python/functions.sh
@@ -27,7 +27,7 @@ function getAgent() {
 	"${PYTHON}" -m pip install --upgrade build
         "${PIP}" install decorator
 	"${PYTHON}" -m build
-	"${PIP}" install dist/kieker-monitoring-for-python-0.0.1.tar.gz
+	"${PIP}" install dist/kieker_monitoring_for_python-0.0.1.tar.gz
 	cd "${BASE_DIR}"
 }
 


### PR DESCRIPTION
This fix resolves two problems.

1. The v69.3.0 release of the Python3 package setuptools enforces the PEP~625 proposal [0], which replaces hyphens with underbars in a package name. Therefore I made the following changes:

Kieker-python/functions.sh
```bash
- "${PIP}" install dist/kieker-monitoring-for-python-0.0.1.tar.gz
+ "${PIP}" install dist/kieker_monitoring_for_python-0.0.1.tar.gz
```

2. Temurin JDK 21 image (based on Alpine Linux 3.19, 3.19.2) comes up with the v23.3.1 release of the Python3 package pip. Its v23.0 enforces the PEP~668 proposal [1], which raises an error when installing a local package against the OS-installed Python environment. Therefore I made the following changes:

Kieker-python/benchmark.sh
```
+ VENV_DIR="${HOME}/venv/moobench"
+ python3 -m venv ${VENV_DIR}
+ source ${VENV_DIR}/bin/activate +
  # configure base dir
  BASE_DIR=$(cd "$(dirname "$0")"; pwd)

  # ...

  info "Done."

+ deactivate
+ rm -rf ${VENV_DIR} +
  exit 0 # end
```
[0]: https://github.com/pypa/setuptools/blob/v69.3.0/NEWS.rst
[1]: https://github.com/pypa/pip/blob/23.0/NEWS.rst