### PR TITLE
[KIEKER-1990] Performance Benchmarks for OpenTelemetry and inspectIT don't show results

### DIFF
--- a/tools/compile-results/src/main/java/moobench/tools/results/stages/GenerateHtmlTableStage.java
+++ b/tools/compile-results/src/main/java/moobench/tools/results/stages/GenerateHtmlTableStage.java
@@ -21,7 +21,7 @@ public class GenerateHtmlTableStage extends AbstractTransformation<TableInformat
     protected void execute(final TableInformation tableInformation) throws Exception {
         String content = "<table>\n" + "  <tr>\n" + "    <th>setup</th>\n" + "    <th>run</th>\n"
                 + "    <th>mean</th>\n" + "    <th>ci</th>\n" + "    <th>sd</th>\n" + "    <th>1.quartile</th>\n"
-                + "    <th>median</th>\n" + "    <th>3.quartile</th>\n" + "    <th>min</th>\n" + "    <th>max</th>\n"
+                + "    <th>median</th>\n" + "    <th>3.quartile</th>\n" + "    <th>max</th>\n" + "    <th>min</th>\n"
                 + "  </tr>\n";
         final Set<String> currentKeySet = tableInformation.getCurrent().getMeasurements().keySet();
         final Set<String> previousKeySet = tableInformation.getPrevious().getMeasurements().keySet();


### PR DESCRIPTION
## [Performance benchmarks page](https://kieker-monitoring.net/performance-benchmarks/)

The WordPress Visualizer plugin started to monetize on the feature reading from a URL source. Another plugin, wpDataTables, seems to provide the same feature (rendering with Google Charts) without making a noticeable visual difference.

I made a minor fix to the HTML generator stage.