### PR TITLE
Update dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,8 @@
 #FROM openjdk:13-jdk-alpine
-FROM eclipse-temurin:21-jdk-alpine 
+FROM eclipse-temurin:21-jdk
 
 RUN echo "jenkins:x:2030:100:guest:/home/jenkins:/sbin/nologin" >> /etc/passwd && \
     mkdir /home/jenkins && chmod 777 /home/jenkins && \ 
-    apk update && \
-    apk add git openssh zip R bash curl python3 py3-pip
+    apt -y update && apt -y upgrade && \
+    apt -y install git openssh-server zip unzip r-base-core bash curl python3-pip
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 #FROM openjdk:13-jdk-alpine
 FROM eclipse-temurin:21-jdk
 
-RUN echo "jenkins:x:2030:100:guest:/home/jenkins:/sbin/nologin" >> /etc/passwd && \
+RUN echo "jenkins:x:4040:7001:guest:/home/jenkins:/sbin/nologin" >> /etc/passwd && \
     mkdir /home/jenkins && chmod 777 /home/jenkins && \ 
     apt -y update && apt -y upgrade && \
     apt -y install git openssh-server zip unzip r-base-core bash curl python3-pip

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,5 +4,5 @@ FROM eclipse-temurin:21-jdk
 RUN echo "jenkins:x:4040:7001:guest:/home/jenkins:/sbin/nologin" >> /etc/passwd && \
     mkdir /home/jenkins && chmod 777 /home/jenkins && \ 
     apt -y update && apt -y upgrade && \
-    apt -y install git openssh-server zip unzip r-base-core bash curl python3-pip
+    apt -y install git openssh-server zip unzip r-base-core bash curl python3-pip python3-venv
 


### PR DESCRIPTION
The merge changes the docker image from `eclipse-temurin:21-jdk-alpine` to `eclipse-temurin:21-jdk`. It is partly an effort for migrating Cloudprofiler into MooBench. It will take some time to run Cloudprofiler on the Alpine Linux. The changes are minimal, and installed packages are more or less the same. I tested running MooBench on the new Dockerfile on a test Jenkins server.