### PR TITLE
Use the original user id

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 #FROM openjdk:13-jdk-alpine
 FROM eclipse-temurin:21-jdk
 
-RUN echo "jenkins:x:4040:7001:guest:/home/jenkins:/sbin/nologin" >> /etc/passwd && \
+RUN echo "jenkins:x:2030:100:guest:/home/jenkins:/sbin/nologin" >> /etc/passwd && \
     mkdir /home/jenkins && chmod 777 /home/jenkins && \ 
     apt -y update && apt -y upgrade && \
     apt -y install git openssh-server zip unzip r-base-core bash curl python3-pip python3-venv


### PR DESCRIPTION
Jenkins seems to use hard-coded user id for the docker-run command on the installed machine, which I was not aware of. From the [Jenkins build log](https://build.se.informatik.uni-kiel.de/view/Kieker/job/kieker-moobench/job/main/339/consoleFull):
```bash
$ docker run -t -d -u 2030:2030 -w /home/jenkins-agent/workspace/kieker-moobench_main -v /home/jenkins-agent/workspace/kieker-moobench_main:/home/jenkins-agent/workspace/kieker-moobench_main:rw,z -v /home/jenkins-agent/workspace/kieker-moobench_main@tmp:/home/jenkins-agent/workspace/kieker-moobench_main@tmp:rw,z
```
In the above log, Jenkins uses 2030, which is assigned to the ``jenkins`` user&user group in the physical build server. In [the previous Dockerfile](https://github.com/kieker-monitoring/moobench/blob/6d2d83ac639e86cf1848073ca179479fe12f9ef1/docker/Dockerfile#L4), we used 2030:100:
```Dockerfile
RUN echo "jenkins:x:2030:100:guest:/home/jenkins:/sbin/nologin" >> /etc/passwd && \
```
I think reverting back to this will fix the folder creation permission issue.