### PR TITLE
Change scouter configurations.

### DIFF
--- a/.github/workflows/benchmarkScouterJava.yaml
+++ b/.github/workflows/benchmarkScouterJava.yaml
@@ -30,7 +30,7 @@ jobs:
         run: |
           ./setup.sh
           cd frameworks/Scouter-java/
-          export MOOBENCH_CONFIGURATIONS="0 1 2 3"
+          export MOOBENCH_CONFIGURATIONS="0 1 2"
           export NUM_OF_LOOPS=3
           ./benchmark.sh 
           cd results-Scouter-java

--- a/.github/workflows/executeScouterJava.yaml
+++ b/.github/workflows/executeScouterJava.yaml
@@ -42,9 +42,9 @@ jobs:
           ./benchmark.sh 
           unzip results-Scouter-java/results.zip 
           measuredValues=$(cat raw-1-10-* | wc -l) 
-          if [ $measuredValues -ne 40 ] 
+          if [ $measuredValues -ne 30 ] 
           then
-            echo "It should be 40 measured values, but was $measuredValues"
+            echo "It should be 30 measured values, but was $measuredValues"
             exit 1
           fi
 

--- a/frameworks/Scouter-java/benchmark.sh
+++ b/frameworks/Scouter-java/benchmark.sh
@@ -27,7 +27,7 @@ fi
 
 if [ -z "$MOOBENCH_CONFIGURATIONS" ]
 then
-	MOOBENCH_CONFIGURATIONS="0 1 2 3"
+	MOOBENCH_CONFIGURATIONS="0 1 2"
 	echo "Setting default configuration $MOOBENCH_CONFIGURATIONS"
 fi
 echo "Running configurations: $MOOBENCH_CONFIGURATIONS"
@@ -71,11 +71,9 @@ declare -a SCOUTER_CONFIG
 
 SCOUTER_CONFIG[0]="${JAVA_ARGS}"
 
-SCOUTER_CONFIG[1]="${SCOUTER_CONFIG[0]} -javaagent:${AGENT} -Dobj_name=moobench-benchmark -Dnet_collector_ip=127.0.0.1"
+SCOUTER_CONFIG[1]="${SCOUTER_CONFIG[0]} -javaagent:${AGENT} -Dobj_name=moobench-benchmark -Dnet_collector_ip=127.0.0.1 -Dhook_service_patterns=${APP_CLASS}.monitoredMethod -Dhook_method_patterns=moobench.application.*.*"
 
-SCOUTER_CONFIG[2]="${SCOUTER_CONFIG[1]} -Dhook_service_patterns=${APP_CLASS}.monitoredMethod -Dhook_method_patterns=moobench.application.*.*"
-
-SCOUTER_CONFIG[3]="${SCOUTER_CONFIG[2]} -Dprofile_method_enabled=false"
+SCOUTER_CONFIG[2]="${SCOUTER_CONFIG[1]} -Dprofile_method_enabled=false"
 
 executeAllLoops
 

--- a/frameworks/Scouter-java/labels.sh
+++ b/frameworks/Scouter-java/labels.sh
@@ -1,4 +1,3 @@
 TITLE[0]="No instrumentation"
-TITLE[1]="Default Scouter"
-TITLE[2]="Method Profiling"
-TITLE[3]="No Profiling"
+TITLE[1]="Instrumentation and Profiling"
+TITLE[2]="Disabled Profiling"


### PR DESCRIPTION
This changes the previous 4 configurations to three configurations as discussed last month: 
No instrumentation, instrumentation and profiling, no profiling

The already collected data should probably be deleted as the labels no longer match.