### PR TITLE
Fixed stddev calculation

### DIFF
--- a/analysis/getGHActionsFormat.sh
+++ b/analysis/getGHActionsFormat.sh
@@ -21,7 +21,7 @@ do
    values=$(
    for file in $(ls raw-*-$size-$variant.csv)
    do
-      cat $file | awk -F';' '{print $2}' | getSum | awk '{print $2}'
+      cat $file | awk -F';' '{print $2}'
    done | getSum)
    value=$(echo $values | awk '{print $2}')
    standardDeviation=$(echo $values | awk '{print $5}')


### PR DESCRIPTION
Could you check and confirm the pull request?

I made a small test case for this:

```bash
wc -l *txt
 2000000 01.txt
 2000000 02.txt
 2000000 03.txt
 2000000 04.txt
 2000000 05.txt
 2000000 06.txt
 2000000 07.txt
 2000000 08.txt
 2000000 09.txt
 2000000 10.txt
20000000 total
```
Each file is filled with `$RANDOM % 1000` values. For example, `01.txt`:
```bash
head -5 01.txt
147
885
450
270
19
```
I made `test.sh` based on the script in the pull request:
```bash
#!/bin/bash

function getSum {
  awk '{sum += $1; square += $1^2} END {print "Average: "sum/NR" Standard Deviation: "sqrt(square / NR - (sum/NR)^2)" Count: "NR}'
}

for file in $(ls *txt)
do
  cat $file | getSum | awk '{print $2}'
done |getSum

for file in $(ls *txt)
do
  cat $file
done |getSum
```

The result:
```bash
./test.sh
Average: 496.795 Standard Deviation: 0.198379 Count: 10
Average: 496.795 Standard Deviation: 287.826 Count: 20000000
```