### PR TITLE
Drop cpu check for the Prometheus configuration in Opentelemetry-java

### DIFF
--- a/common-functions.sh
+++ b/common-functions.sh
@@ -92,8 +92,25 @@ function periodicallyCurlPrometheus {
 }
 
 function startPrometheus {
-	periodicallyCurlPrometheus $1 &
+	if [ -d prometheus-3.6.0.linux-arm64 ]
+	then
+	  startPrometheusARM64 &
+	else
+	  periodicallyCurlPrometheus $1 &
+	fi
 	pid=$!
+}
+
+function startPrometheusARM64 {
+	if [ ! -d prometheus-3.6.0.linux-arm64 ]
+	then
+	  wget https://github.com/prometheus/prometheus/releases/download/v3.6.0/prometheus-3.6.0.linux-arm64.tar.gz
+		tar -xvf prometheus-3.6.0.linux-arm64.tar.gz
+		rm prometheus-3.6.0.linux-arm64.tar.gz
+	fi
+	cd prometheus-3.6.0.linux-arm64
+	./prometheus &> prometheus.log &
+	cd ..
 }
 
 function stopBackgroundProcess {

--- a/frameworks/OpenTelemetry-java/labels.sh
+++ b/frameworks/OpenTelemetry-java/labels.sh
@@ -2,9 +2,9 @@ TITLE[0]="No instrumentation"
 TITLE[1]="No logging"
 TITLE[2]="Logging"
 TITLE[3]="Zipkin"
+TITLE[4]="Prometheus"
 MACHINE_TYPE=`uname -m`; 
 if [ ${MACHINE_TYPE} == 'x86_64' ]
 then
-	TITLE[4]="Prometheus"
 	#TITLE[5]="OpenTelemetry Jaeger"
 fi


### PR DESCRIPTION
Would it be okay to drop cpu check for Prometheus? It will help running the measurement on non Intel CPUs