### PR TITLE
Fixed the InstrumentOnImportFinder instrumentation method

### DIFF
--- a/frameworks/Kieker-python/config.rc
+++ b/frameworks/Kieker-python/config.rc
@@ -17,7 +17,7 @@ DATA_DIR="${BASE_DIR}/data"
 
 KIEKER_4_PYTHON_REPO_URL="https://github.com/kieker-monitoring/kieker-lang-pack-python.git"
 KIEKER_4_PYTHON_DIR="${BASE_DIR}/kieker-lang-pack-python"
-KIEKER_4_PYTHON_BRANCH="ast_import_hook"
+KIEKER_4_PYTHON_BRANCH="ast_import_hook_new"
 
 RECEIVER_ARCHIVE="${MAIN_DIR}/tools/receiver/build/distributions/receiver.tar"
 

--- a/frameworks/Kieker-python/functions.sh
+++ b/frameworks/Kieker-python/functions.sh
@@ -128,7 +128,10 @@ function executeBenchmarkBody() {
   executeExperiment "$loop" "$recursion" "$index"
 
   if [[ "${RECEIVER_PID}" ]] ; then
-    kill -9 "${RECEIVER_PID}"
+    if ps -p "${RECEIVER_PID}" > /dev/null
+    then
+      kill -TERM "${RECEIVER_PID}"
+    fi
     unset RECEIVER_PID
   fi
 }

--- a/frameworks/Kieker-python/functions.sh
+++ b/frameworks/Kieker-python/functions.sh
@@ -57,7 +57,7 @@ EOF
 function createMonitoring() {
     mode="$1"
 cat > "${BASE_DIR}/monitoring.ini" << EOF
-[Main]
+[General]
 mode = ${mode}
 
 [Tcp]
@@ -92,7 +92,9 @@ function executeExperiment() {
     createMonitoring ${mode}
     createConfig ${inactive} ${instrument} ${approach} ${loop}
 
+    cd ../../tools/pybenchmark/
     "${PYTHON}" "${MOOBENCH_BIN_PY}" "${BASE_DIR}/config.ini"
+    cd ${BASE_DIR}
 
     if [ ! -f "${RESULT_FILE}" ] ; then
         info "---------------------------------------------------"
@@ -126,11 +128,8 @@ function executeBenchmarkBody() {
   executeExperiment "$loop" "$recursion" "$index"
 
   if [[ "${RECEIVER_PID}" ]] ; then
-    if ps -p "${RECEIVER_PID}" > /dev/null
-    then
-      kill -TERM "${RECEIVER_PID}"
-    fi
-     unset RECEIVER_PID
+    kill -9 "${RECEIVER_PID}"
+    unset RECEIVER_PID
   fi
 }
 


### PR DESCRIPTION
### Fixed
* After moving the Python benchmark and its drivers to `tools/pybenchmark`, Kieker-python's `InstrumentOnImportFinder` instrumentation method was not working correctly. We can just change the current working directory before launching the benchmark each time.
* We plan to use the master branch of the [kieker-lang-pack-python](https://github.com/kieker-monitoring/kieker-lang-pack-python) repository. For now, I made another branch `ast_import_hook_new` which merged all new changes from the master.
* Currently the `PostImportFinder` instrumentation method does not seem to be effective. It is okay until Python 3.10 (I checked), but becomes ineffective from Python 3.11, I will keep up with this.