### PR TITLE
Fixes for ARM board

### DIFF
--- a/common-functions.sh
+++ b/common-functions.sh
@@ -92,8 +92,25 @@ function periodicallyCurlPrometheus {
 }
 
 function startPrometheus {
-	periodicallyCurlPrometheus $1 &
+	if [ -d prometheus-3.6.0.linux-arm64 ]
+	then
+	  startPrometheusARM64 &
+	else
+	  periodicallyCurlPrometheus $1 &
+	fi
 	pid=$!
+}
+
+function startPrometheusARM64 {
+	if [ ! -d prometheus-3.6.0.linux-arm64 ]
+	then
+	  wget https://github.com/prometheus/prometheus/releases/download/v3.6.0/prometheus-3.6.0.linux-arm64.tar.gz
+		tar -xvf prometheus-3.6.0.linux-arm64.tar.gz
+		rm prometheus-3.6.0.linux-arm64.tar.gz
+	fi
+	cd prometheus-3.6.0.linux-arm64
+	./prometheus &> prometheus.log &
+	cd ..
 }
 
 function stopBackgroundProcess {

--- a/common-functions.sh
+++ b/common-functions.sh
@@ -115,8 +115,12 @@ function startPrometheusARM64 {
 }
 
 function stopBackgroundProcess {
-	kill $(cat /tmp/prometheus.pid)
-	rm /tmp/prometheus.pid
+	if [ -f /tmp/prometheus.pid ]
+	then
+		pid=$(cat /tmp/prometheus.pid)
+		rm /tmp/prometheus.pid
+	fi
+	kill $pid
 }
 
 function writeConfiguration() {

--- a/common-functions.sh
+++ b/common-functions.sh
@@ -92,29 +92,31 @@ function periodicallyCurlPrometheus {
 }
 
 function startPrometheus {
-	if [ -d prometheus-3.6.0.linux-arm64 ]
+	if [ ${MACHINE_TYPE} == 'aarch64' ]
 	then
-	  startPrometheusARM64 &
+		startPrometheusARM64
 	else
-	  periodicallyCurlPrometheus $1 &
+		periodicallyCurlPrometheus $1 &
+		pid=$!
 	fi
-	pid=$!
 }
 
 function startPrometheusARM64 {
 	if [ ! -d prometheus-3.6.0.linux-arm64 ]
 	then
-	  wget https://github.com/prometheus/prometheus/releases/download/v3.6.0/prometheus-3.6.0.linux-arm64.tar.gz
+		wget https://github.com/prometheus/prometheus/releases/download/v3.6.0/prometheus-3.6.0.linux-arm64.tar.gz
 		tar -xvf prometheus-3.6.0.linux-arm64.tar.gz
 		rm prometheus-3.6.0.linux-arm64.tar.gz
 	fi
 	cd prometheus-3.6.0.linux-arm64
 	./prometheus &> prometheus.log &
+	echo $! > /tmp/prometheus.pid
 	cd ..
 }
 
 function stopBackgroundProcess {
-	kill $pid
+	kill $(cat /tmp/prometheus.pid)
+	rm /tmp/prometheus.pid
 }
 
 function writeConfiguration() {

--- a/frameworks/OpenTelemetry-java/benchmark.sh
+++ b/frameworks/OpenTelemetry-java/benchmark.sh
@@ -26,8 +26,6 @@ else
 	exit 1
 fi
 
-MACHINE_TYPE=`uname -m`
-
 if [ -z "$MOOBENCH_CONFIGURATIONS" ]
 then
 	MOOBENCH_CONFIGURATIONS="0 1 3 4"

--- a/frameworks/OpenTelemetry-java/benchmark.sh
+++ b/frameworks/OpenTelemetry-java/benchmark.sh
@@ -26,6 +26,8 @@ else
 	exit 1
 fi
 
+MACHINE_TYPE=`uname -m`
+
 if [ -z "$MOOBENCH_CONFIGURATIONS" ]
 then
 	MOOBENCH_CONFIGURATIONS="0 1 3 4"

--- a/frameworks/OpenTelemetry-java/labels.sh
+++ b/frameworks/OpenTelemetry-java/labels.sh
@@ -2,9 +2,9 @@ TITLE[0]="No instrumentation"
 TITLE[1]="No logging"
 TITLE[2]="Logging"
 TITLE[3]="Zipkin"
+TITLE[4]="Prometheus"
 MACHINE_TYPE=`uname -m`; 
 if [ ${MACHINE_TYPE} == 'x86_64' ]
 then
-	TITLE[4]="Prometheus"
 	#TITLE[5]="OpenTelemetry Jaeger"
 fi

--- a/frameworks/OpenTelemetry-java/labels.sh
+++ b/frameworks/OpenTelemetry-java/labels.sh
@@ -3,8 +3,4 @@ TITLE[1]="No logging"
 TITLE[2]="Logging"
 TITLE[3]="Zipkin"
 TITLE[4]="Prometheus"
-MACHINE_TYPE=`uname -m`; 
-if [ ${MACHINE_TYPE} == 'x86_64' ]
-then
-	#TITLE[5]="OpenTelemetry Jaeger"
-fi
+#TITLE[5]="OpenTelemetry Jaeger"

--- a/frameworks/Skywalking-java/functions.sh
+++ b/frameworks/Skywalking-java/functions.sh
@@ -40,7 +40,8 @@ function startSkywalkingServer {
   ./oapService.sh &
   SKYWALKING_PID=$!
   cd "${BASE_DIR}"
-  while ! nc -z localhost 11800; do
+# while ! nc -z localhost 11800; do
+  while ! timeout 1 bash -c "cat < /dev/null > /dev/tcp/localhost/11800" 2>/dev/null; do
     sleep 2
   done
 }

--- a/init.sh
+++ b/init.sh
@@ -34,7 +34,7 @@ if [ -z $DEBUG ]; then
 	DEBUG=false		## false
 fi
 
-
+MACHINE_TYPE=`uname -m`
 
 # load configuration and common functions
 if [ -f "${BASE_DIR}/config.rc" ] ; then


### PR DESCRIPTION
* Fixes to run MooBench on Raspberry Pi 5, which is internally BCM2712 (ARM Cortex-A76) and has 8 GB RAM; tested on Debian Linux 13.
  * `MACHINE_TYPE` variable needs to be initialized in `init.sh`, allowing the variable on all target tracing frameworks
  * PID of prometheus is stored in a temporary file.
  * `nc` is not available in Debian's default installation, so use `timeout`-based socket checking instead

Currently prometheus will execute on the ARM architecture. It needs to be extended to the x86_64 architecture.