### PR TITLE
Add eBPF-USDT framework for Java method tracing using USDT probes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@ compile-results/
 frameworks/Kieker-python/kieker-lang-pack-python/
 analysis/results_depth/
 analysis/results_threads
+frameworks/eBPF-USDT/java_tracer_usdt
+frameworks/eBPF-USDT/java_tracer_usdt.bpf.o
 
 # Do not store agents
 frameworks/elasticapm-java/elastic-apm-agent.jar
@@ -42,6 +44,8 @@ frameworks/elasticapm-java/results-elasticapm-java/
 frameworks/pinpoint-java/results-pinpoint-java/
 frameworks/pinpoint-java/exp-results-pinpoint-java/
 frameworks/bpftrace-java/results-bpftrace-java/
+frameworks/eBPF-USDT/results-eBPF-USDT/
+frameworks/eBPF-USDT/data/
 
 # Do not store pinpoint temporary data
 frameworks/pinpoint-java/logs/

--- a/frameworks/eBPF-USDT/Makefile
+++ b/frameworks/eBPF-USDT/Makefile
@@ -1,0 +1,34 @@
+ARCH := $(shell uname -m)
+ifeq ($(ARCH),x86_64)
+  ARCH_FLAG  := x86
+  GNU_ARCH   := x86_64-linux-gnu
+else
+  ARCH_FLAG  := arm64
+  GNU_ARCH   := aarch64-linux-gnu
+endif
+
+BPF_SRC := java_tracer_usdt.bpf.c
+BPF_OBJ := java_tracer_usdt.bpf.o
+CPP_SRC := java_tracer_usdt.cpp
+BIN     := java_tracer_usdt
+
+.PHONY: all clean symlink
+
+all: symlink $(BPF_OBJ) $(BIN)
+
+symlink:
+	@if [ ! -e /usr/include/asm ]; then \
+		echo "Creating asm symlink..."; \
+		sudo ln -sf /usr/include/$(GNU_ARCH)/asm /usr/include/asm; \
+	fi
+
+$(BPF_OBJ): $(BPF_SRC)
+	clang -g -O2 -target bpf -D__TARGET_ARCH_$(ARCH_FLAG) \
+		-c $< -o $@
+
+$(BIN): $(CPP_SRC)
+	g++ -o $@ $< -lbpf -lelf -lz
+	sudo setcap cap_bpf,cap_perfmon=eip $@
+
+clean:
+	rm -f $(BPF_OBJ) $(BIN)

--- a/frameworks/eBPF-USDT/README.md
+++ b/frameworks/eBPF-USDT/README.md
@@ -1,0 +1,56 @@
+## eBPF-USDT Framework for MooBench
+
+Traces Java method calls using eBPF USDT via `-XX:+DTraceMethodProbes`.
+
+## Requirements
+
+| Requirement | Version |
+|---|---|
+| Linux kernel | ≥ 5.15 |
+| OpenJDK | 21+ |
+| Architecture | `x86_64` or `aarch64` |
+| clang | any recent version |
+| g++ | any recent version |
+| libbpf-dev | Ubuntu/Debian: `sudo apt install libbpf-dev` / RHEL-based: `sudo dnf install libbpf-devel` |
+| r-base | Ubuntu/Debian: `sudo apt install r-base` / RHEL-based: `sudo dnf install R-base` |
+
+## Installation
+
+Build the tracer from inside the framework directory:
+
+```bash
+cd path/to/moobench/frameworks/eBPF-USDT
+make
+```
+
+`make` will:
+- Grant the tracer the Linux capabilities it needs (`cap_bpf`, `cap_perfmon`)
+
+The `setcap` step requires sudo every time you compile the tracer
+
+## Running the benchmark
+
+```bash
+./benchmark.sh
+```
+
+Results are written to `results-eBPF-USDT/`. Binary trace files (write mode) are written to `data/`.
+
+## Configurations
+
+| Index | Description |
+|---|---|
+| 0 | No instrumentation — baseline |
+| 1 | `-XX:+DTraceMethodProbes` enabled, no tracer attached |
+| 2 | Tracer attached, count mode (events consumed but not written) |
+| 4 | Tracer attached, write mode (events written to binary file) |
+
+## How it works
+
+The benchmark uses a fake `JAVA_HOME` to intercept Java invocations and route them
+through `java_wrapper.sh`. The wrapper starts Java normally, waits for `libjvm.so` to
+load, then attaches the tracer process which loads the BPF programs and hooks into the
+HotSpot `method__entry` and `method__return` USDT probes.
+
+The BPF programs filter events to only the target class (`MonitoredClassSimple`) and
+records data in a ring buffer, which the userspace tracer drains continuously.

--- a/frameworks/eBPF-USDT/benchmark.sh
+++ b/frameworks/eBPF-USDT/benchmark.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+BASE_DIR=$(cd "$(dirname "$0")"; pwd)
+MAIN_DIR="${BASE_DIR}/../.."
+
+if [ ! -d "${BASE_DIR}" ] ; then exit 1; fi
+if [ -f "${MAIN_DIR}/init.sh" ] ; then source "${MAIN_DIR}/init.sh"; else exit 1; fi
+
+MOOBENCH_CONFIGURATIONS="0 1 2 4"
+echo "Running eBPF configurations: $MOOBENCH_CONFIGURATIONS"
+
+cd "${BASE_DIR}"
+checkDirectory data-dir "${DATA_DIR}" create
+cleanupResults
+mkdir -p $RESULTS_DIR
+PARENT=$(dirname "${RESULTS_DIR}")
+checkDirectory result-base "${PARENT}"
+
+# Create Fake JAVA_HOME to force wrapper usage
+FAKE_JAVA_HOME="${BASE_DIR}/fake_java_home"
+mkdir -p "${FAKE_JAVA_HOME}/bin"
+
+# Make the wrapper executable
+chmod +x "${BASE_DIR}/java_wrapper.sh"
+
+# Symlink the wrapper to be java in our fake home
+ln -sf "${BASE_DIR}/java_wrapper.sh" "${FAKE_JAVA_HOME}/bin/java"
+
+# Export this new JAVA_HOME so MooBench picks it up
+export JAVA_HOME="${FAKE_JAVA_HOME}"
+echo "Setting JAVA_HOME to: ${JAVA_HOME}"
+
+JAVA_BIN="${BASE_DIR}/java_wrapper.sh"
+# We check the wrapper, not system java
+checkExecutable java "${JAVA_BIN}"
+checkExecutable moobench "${MOOBENCH_BIN}"
+checkFile R-script "${RSCRIPT_PATH}"
+
+JAVA_ARGS="-Xms1G -Xmx2G"
+
+declare -a WRITER_CONFIG
+# 0: Baseline
+WRITER_CONFIG[0]=""
+# 1: Deactivated
+WRITER_CONFIG[1]="-XX:+DTraceMethodProbes"
+# 2: No collection (Count mode)
+WRITER_CONFIG[2]="-XX:+DTraceMethodProbes -DEBPF_MODE=count"
+# 4: Binary file (Write mode)
+WRITER_CONFIG[4]="-XX:+DTraceMethodProbes -DEBPF_MODE=write"
+
+executeAllLoops
+
+rm -rf "${FAKE_JAVA_HOME}"
+
+exit 0

--- a/frameworks/eBPF-USDT/config.rc
+++ b/frameworks/eBPF-USDT/config.rc
@@ -1,0 +1,10 @@
+# config.rc - Core paths for MooBench
+
+# eBPF probe attachment requires minimum method time to attach 
+METHOD_TIME=500000
+
+DATA_DIR="${BASE_DIR}/data"
+MOOBENCH_BIN="${MAIN_DIR}/benchmark/bin/benchmark"
+
+# path to the R analysis script
+RSCRIPT_PATH="${MAIN_DIR}/frameworks/statistics.r"

--- a/frameworks/eBPF-USDT/functions.sh
+++ b/frameworks/eBPF-USDT/functions.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+function executeBenchmark() {
+    # i comes from MooBench external loop
+    local loop="${i}"
+    local recursion="${RECURSION_DEPTH}"
+
+    for index in $MOOBENCH_CONFIGURATIONS; do
+        info " # ${loop}.${recursion}.${index} ${TITLE[$index]}"
+
+        export JAVA_OPTS="${JAVA_ARGS} ${WRITER_CONFIG[$index]}"
+
+        local RESULT_FILE="${RAWFN}-${loop}-${recursion}-${index}.csv"
+        local LOG_FILE="${RESULTS_DIR}/output_${loop}_${recursion}_${index}.txt"
+
+        "${MOOBENCH_BIN}" \
+            --output-filename "${RESULT_FILE}" \
+            --total-calls "${TOTAL_NUM_OF_CALLS}" \
+            --method-time "${METHOD_TIME}" \
+            --total-threads "${THREADS}" \
+            --recursion-depth "${recursion}" \
+            --application "moobench.application.MonitoredClassSimple" &> "${LOG_FILE}"
+
+        sleep "${SLEEP_TIME}"
+    done
+}

--- a/frameworks/eBPF-USDT/java_tracer_usdt.bpf.c
+++ b/frameworks/eBPF-USDT/java_tracer_usdt.bpf.c
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: GPL-2.0
+#include <stdbool.h>
+
+#ifdef __TARGET_ARCH_arm64
+struct user_pt_regs { unsigned long long regs[31]; unsigned long long sp; unsigned long long pc; unsigned long long pstate; };
+struct pt_regs { union { struct user_pt_regs user_regs; struct { unsigned long long regs[31]; unsigned long long sp; unsigned long long pc; unsigned long long pstate; }; }; unsigned long long orig_x0; unsigned long long syscallno; unsigned long long orig_addr_limit; unsigned long long pmr_save; unsigned long long stackframe[2]; unsigned long long lockdep_hardirqs; unsigned long long exit_rcu; };
+#endif
+
+#ifdef __TARGET_ARCH_x86
+struct pt_regs { unsigned long r15; unsigned long r14; unsigned long r13; unsigned long r12; unsigned long rbp; unsigned long rbx; unsigned long r11; unsigned long r10; unsigned long r9; unsigned long r8; unsigned long rax; unsigned long rcx; unsigned long rdx; unsigned long rsi; unsigned long rdi; unsigned long orig_rax; unsigned long rip; unsigned long cs; unsigned long eflags; unsigned long rsp; unsigned long ss; };
+#endif
+
+#include <linux/bpf.h>
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+#include <bpf/usdt.bpf.h>
+
+// Key for storing start times
+struct event_key {
+    __u64 tid;
+    __u64 depth;
+};
+
+struct method_entry {
+    __u64 start_time;
+};
+
+struct method_event {
+    __u64 pid;
+    __u64 tid;
+    __u64 entry_time;
+    __u64 exit_time;
+    __u64 depth;
+    char method_name[64];
+};
+
+// --- MAPS ---
+
+// Map 1: Tracks current recursion depth for each thread
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __uint(max_entries, 256);
+    __type(key, __u64);
+    __type(value, __u64);
+} depth_map SEC(".maps");
+
+// Map 2: Stores start times
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __uint(max_entries, 256);
+    __type(key, struct event_key);
+    __type(value, struct method_entry);
+} method_entries SEC(".maps");
+
+// Map 3: Ringbuffer for output
+struct {
+    __uint(type, BPF_MAP_TYPE_RINGBUF);
+    __uint(max_entries, 4 * 1024 * 1024);
+} events SEC(".maps");
+
+
+// --- HELPERS ---
+
+static __always_inline int is_monitored_class(char *class_name) {
+    // Only trace target
+    char buf[41] = {};
+    if (bpf_probe_read_user(buf, sizeof(buf), class_name) < 0) return 0;
+    const char target[] = "moobench/application/MonitoredClassSimple";
+    return __builtin_memcmp(buf, target, 41) == 0;
+}
+
+SEC("usdt")
+int BPF_USDT(handle_method_entry, long thread_id, char *class_name, int class_len, char *method_name, int method_len)
+{
+    // Skip bpf_probe_read_user for non-target classes
+    if (class_len != 41) return 0;
+
+    __u64 pid_tgid = bpf_get_current_pid_tgid();
+    __u64 tid = pid_tgid & 0xFFFFFFFF;
+
+    // 1. Only trace target
+    if (!is_monitored_class(class_name)) return 0;
+
+    // 2. Increment depth
+    __u64 depth = 0;
+    __u64 *depth_ptr = bpf_map_lookup_elem(&depth_map, &tid);
+    if (depth_ptr) {
+        depth = *depth_ptr + 1;
+    } else {
+        depth = 1;
+    }
+    bpf_map_update_elem(&depth_map, &tid, &depth, BPF_ANY);
+
+    // 3. Stire start time
+    struct event_key key = {};
+    key.tid = tid;
+    key.depth = depth;
+
+    struct method_entry entry = {};
+    entry.start_time = bpf_ktime_get_ns();
+
+    bpf_map_update_elem(&method_entries, &key, &entry, BPF_ANY);
+
+    return 0;
+}
+
+SEC("usdt")
+int BPF_USDT(handle_method_return, long thread_id, char *class_name, int class_len, char *method_name, int method_len)
+{
+    if (class_len != 41) return 0;
+
+    __u64 pid_tgid = bpf_get_current_pid_tgid();
+    __u64 tid = pid_tgid & 0xFFFFFFFF;
+    __u64 pid = pid_tgid >> 32;
+
+    // 1. Only trace target
+    if (!is_monitored_class(class_name)) return 0;
+
+    // 2. Get current depth
+    __u64 *depth_ptr = bpf_map_lookup_elem(&depth_map, &tid);
+    if (!depth_ptr || *depth_ptr == 0) return 0;
+    __u64 depth = *depth_ptr;
+
+    // 3. Retrieve start time
+    struct event_key key = {};
+    key.tid = tid;
+    key.depth = depth;
+
+    struct method_entry *entry = bpf_map_lookup_elem(&method_entries, &key);
+
+    // 4. Decrement depth
+    __u64 new_depth = depth - 1;
+    if (new_depth == 0) {
+        bpf_map_delete_elem(&depth_map, &tid);
+    } else {
+        bpf_map_update_elem(&depth_map, &tid, &new_depth, BPF_ANY);
+    }
+
+    if (!entry) return 0; // Missed entry
+
+    // 5. Record exit time & cleanup
+    __u64 exit_time = bpf_ktime_get_ns();
+    __u64 entry_time = entry->start_time;
+    bpf_map_delete_elem(&method_entries, &key);
+
+    // 6. Submit event
+    struct method_event *event = bpf_ringbuf_reserve(&events, sizeof(*event), 0);
+    if (!event) return 0;
+
+    event->pid = pid;
+    event->tid = tid;
+    event->entry_time = entry_time;
+    event->exit_time = exit_time;
+    event->depth = depth;
+    // Read only as many bytes as needed
+    __u32 name_len = ((__u32)method_len < sizeof(event->method_name))
+                         ? (__u32)method_len
+                         : sizeof(event->method_name) - 1;
+    bpf_probe_read_user(event->method_name, name_len, method_name);
+
+    bpf_ringbuf_submit(event, 0);
+    return 0;
+}
+
+char LICENSE[] SEC("license") = "GPL";

--- a/frameworks/eBPF-USDT/java_tracer_usdt.cpp
+++ b/frameworks/eBPF-USDT/java_tracer_usdt.cpp
@@ -1,0 +1,197 @@
+#include <iostream>
+#include <string>
+#include <csignal>
+#include <cstring>
+#include <cstdlib>
+#include <unistd.h>
+#include <sys/resource.h>
+#include <bpf/libbpf.h>
+#include <bpf/bpf.h>
+#include <errno.h>
+
+using std::string;
+using std::to_string;
+
+#define LOG(fmt, ...) fprintf(stderr, "[tracer] " fmt "\n", ##__VA_ARGS__)
+
+static string get_bpf_obj_path() {
+    char exe_path[4096] = {};
+    ssize_t len = readlink("/proc/self/exe", exe_path, sizeof(exe_path) - 1);
+    if (len > 0) {
+        string path(exe_path, len);
+        size_t last_slash = path.rfind('/');
+        if (last_slash != string::npos)
+            return path.substr(0, last_slash + 1) + "java_tracer_usdt.bpf.o";
+    }
+    return "java_tracer_usdt.bpf.o";
+}
+
+struct method_event {
+    uint64_t pid;
+    uint64_t tid;
+    uint64_t entry_time;
+    uint64_t exit_time;
+    uint64_t depth;
+    char method_name[64];
+};
+
+static volatile sig_atomic_t exiting = 0;
+static FILE *global_out = nullptr;
+static uint8_t write_buf[8192];
+static size_t buf_pos = 0;
+
+static void sig_handler(int sig) {
+    exiting = 1;
+}
+
+static inline void flush_buf() {
+    if (buf_pos > 0 && global_out) {
+        fwrite(write_buf, 1, buf_pos, global_out);
+        buf_pos = 0;
+    }
+}
+
+static int handle_event(void *ctx, void *data, size_t data_sz) {
+    const struct method_event *e = static_cast<const struct method_event*>(data);
+
+    if (global_out) {
+        // Buffer binary events flush when full
+        if (buf_pos + sizeof(*e) > sizeof(write_buf)) {
+            flush_buf();
+        }
+        memcpy(write_buf + buf_pos, e, sizeof(*e));
+        buf_pos += sizeof(*e);
+    }
+    return 0;
+}
+
+static string find_libjvm_path(pid_t pid) {
+    string maps_file = "/proc/" + to_string(pid) + "/maps";
+    FILE *fp = fopen(maps_file.c_str(), "r");
+    if (!fp) {
+        LOG("ERROR: Failed to open maps file: %s", strerror(errno));
+        return "";
+    }
+
+    char line[1024];
+    string libjvm_path;
+
+    while (fgets(line, sizeof(line), fp)) {
+        if (strstr(line, "libjvm.so")) {
+            char *p = strchr(line, '/');
+            if (p) {
+                char *newline = strchr(p, '\n');
+                if (newline) *newline = '\0';
+                libjvm_path = string(p);
+                break;
+            }
+        }
+    }
+    fclose(fp);
+    return libjvm_path;
+}
+
+int main(int argc, char **argv) {
+    LOG("Tracer starting...");
+    if (argc < 2) {
+        LOG("Usage: %s <PID> [options]", argv[0]);
+        return 1;
+    }
+    
+    pid_t target_pid = std::stoi(argv[1]);
+    string output_file = "ebpf_trace.bin";
+    string mode = "write";
+
+    for (int i = 2; i < argc; i++) {
+        if (strncmp(argv[i], "--output=", 9) == 0) output_file = string(argv[i] + 9);
+        if (strncmp(argv[i], "--mode=",   7) == 0) mode        = string(argv[i] + 7);
+    }
+
+    LOG("Target PID: %d", target_pid);
+    LOG("Mode: %s", mode.c_str());
+
+    if (kill(target_pid, 0) != 0) {
+        LOG("ERROR: PID %d does not exist or permission denied.", target_pid);
+        return 1;
+    }
+
+    if (mode == "write") {
+        LOG("Output File: %s", output_file.c_str());
+        global_out = fopen(output_file.c_str(), "wb");
+        if (!global_out) {
+            LOG("ERROR: Could not open output file!");
+            return 1;
+        }
+    } else {
+        LOG("Count mode: events consumed but not written to disk.");
+    }
+
+    string libjvm_path = find_libjvm_path(target_pid);
+    if (libjvm_path.empty()) {
+        LOG("CRITICAL ERROR: Could not find libjvm.so in process maps.");
+        return 1;
+    }
+    
+    string bpf_obj_path = get_bpf_obj_path();
+    LOG("Loading BPF object: %s", bpf_obj_path.c_str());
+    struct bpf_object *obj = bpf_object__open_file(bpf_obj_path.c_str(), nullptr);
+    if (!obj) {
+        LOG("ERROR: Failed to open BPF object.");
+        return 1;
+    }
+
+    if (bpf_object__load(obj)) {
+        LOG("ERROR: Failed to load BPF object (Verifier/Map error).");
+        return 1;
+    }
+    
+    struct bpf_program *entry_prog = bpf_object__find_program_by_name(obj, "handle_method_entry");
+    struct bpf_program *exit_prog = bpf_object__find_program_by_name(obj, "handle_method_return");
+    
+    if (!entry_prog || !exit_prog) {
+        LOG("ERROR: Could not find BPF programs.");
+        return 1;
+    }
+
+    LOG("Attaching USDT probes...");
+    struct bpf_link *l1 = bpf_program__attach_usdt(entry_prog, target_pid, libjvm_path.c_str(), "hotspot", "method__entry", nullptr);
+    if (!l1) {
+        LOG("ERROR: Failed to attach method__entry: %s", strerror(errno));
+    } else {
+        LOG("Attached method__entry");
+    }
+
+    struct bpf_link *l2 = bpf_program__attach_usdt(exit_prog, target_pid, libjvm_path.c_str(), "hotspot", "method__return", nullptr);
+    if (!l2) {
+        LOG("ERROR: Failed to attach method__return: %s", strerror(errno));
+    } else {
+        LOG("Attached method__return");
+    }
+    
+    int events_fd = bpf_map__fd(bpf_object__find_map_by_name(obj, "events"));
+    struct ring_buffer *rb = ring_buffer__new(events_fd, handle_event, nullptr, nullptr);
+    if (!rb) {
+        LOG("ERROR: Failed to create ring buffer.");
+        return 1;
+    }
+    
+    signal(SIGINT, sig_handler);
+    signal(SIGTERM, sig_handler);
+    
+    LOG("Initialization complete. Entering event loop...");
+    while (!exiting) {
+        int err = ring_buffer__poll(rb, 100);
+        if (err == -EINTR) break;
+        
+        if (kill(target_pid, 0) != 0) {
+            LOG("Target process died. Exiting.");
+            break; 
+        }
+    }
+    
+    flush_buf();
+    if (global_out) fclose(global_out);
+    ring_buffer__free(rb);
+    bpf_object__close(obj);
+    return 0;
+}

--- a/frameworks/eBPF-USDT/java_wrapper.sh
+++ b/frameworks/eBPF-USDT/java_wrapper.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+
+# Resolve BASE_DIR through symlinks
+SCRIPT_PATH=$(readlink -f "$0")
+BASE_DIR=$(cd "$(dirname "$SCRIPT_PATH")"; pwd)
+TRACER_BIN="${BASE_DIR}/java_tracer_usdt"
+DATA_OUT="${BASE_DIR}/data"
+
+# Ceanup trap
+cleanup() {
+    if [ -n "$WATCHDOG_PID" ]; then kill $WATCHDOG_PID 2>/dev/null; fi
+    if [ -n "$TRACER_PID" ]; then
+        kill -SIGINT $TRACER_PID 2>/dev/null
+        sleep 1
+        kill -9 $TRACER_PID 2>/dev/null
+    fi
+    killall -9 java_tracer_usdt 2>/dev/null
+    rm -f "$JAVA_STDOUT_LOG" 2>/dev/null
+}
+trap cleanup EXIT
+
+# Find java
+REAL_JAVA=$(which -a java | grep -v "fake_java_home" | head -n 1)
+if [ -z "$REAL_JAVA" ]; then REAL_JAVA="/usr/bin/java"; fi
+
+# 1. Parse Mode
+MODE="none"
+for arg in "$@"; do
+    if [[ "$arg" == "-DEBPF_MODE=count" ]]; then MODE="count"; fi
+    if [[ "$arg" == "-DEBPF_MODE=write" ]]; then MODE="write"; fi
+done
+
+# 2. Start Real Java
+# For traced modes capture stdout to detect when measurement starts
+if [ "$MODE" != "none" ]; then
+    JAVA_STDOUT_LOG=$(mktemp /tmp/java_stdout.XXXXXX)
+
+    # Use stdbuf to force line-buffered output from tee
+    "$REAL_JAVA" "$@" > >(stdbuf -oL tee "$JAVA_STDOUT_LOG") 2>&1 &
+    JAVA_PID=$!
+else
+    "$REAL_JAVA" "$@" &
+    JAVA_PID=$!
+fi
+
+# START WATCHDOG
+if [ "$MODE" == "write" ] || [ "$MODE" == "count" ]; then
+    WATCHDOG_TIMEOUT=600
+else
+    WATCHDOG_TIMEOUT=120
+fi
+(
+    sleep $WATCHDOG_TIMEOUT
+    if kill -0 $JAVA_PID 2>/dev/null; then
+        kill -9 $JAVA_PID
+    fi
+) &
+WATCHDOG_PID=$!
+
+# 3. Attach Tracer only when benchmark measurement begins
+if [ "$MODE" != "none" ]; then
+    # Wait for libjvm.so to be loaded
+    MAX_RETRIES=50
+    FOUND=0
+    for ((i=0; i<MAX_RETRIES; i++)); do
+        if ! kill -0 $JAVA_PID 2>/dev/null; then break; fi
+        if grep -q "libjvm.so" /proc/$JAVA_PID/maps 2>/dev/null; then FOUND=1; break; fi
+        sleep 0.1
+    done
+
+    if [ $FOUND -eq 1 ]; then
+        # Wait for JVM startup to complete before attaching
+        STARTUP_TIMEOUT=120
+        READY=0
+        for ((i=0; i<STARTUP_TIMEOUT*10; i++)); do
+            # Check marker first
+            if grep -q "Starting benchmark" "$JAVA_STDOUT_LOG" 2>/dev/null; then
+                READY=1
+                break
+            fi
+            if ! kill -0 $JAVA_PID 2>/dev/null; then
+                # Java exited check file one last time
+                sleep 0.2
+                if grep -q "Starting benchmark" "$JAVA_STDOUT_LOG" 2>/dev/null; then
+                    READY=1
+                fi
+                break
+            fi
+            sleep 0.1
+        done
+
+        if [ $READY -eq 1 ] && kill -0 $JAVA_PID 2>/dev/null; then
+            if [ "$MODE" == "write" ]; then
+                OUT_FILE="${DATA_OUT}/ebpf-trace-${JAVA_PID}.bin"
+                "$TRACER_BIN" $JAVA_PID --mode=write --output="$OUT_FILE" >/dev/null 2>&1 &
+                TRACER_PID=$!
+            elif [ "$MODE" == "count" ]; then
+                "$TRACER_BIN" $JAVA_PID --mode=count >/dev/null 2>&1 &
+                TRACER_PID=$!
+            fi
+        fi
+    fi
+fi
+
+# 4. Wait for Java
+wait $JAVA_PID
+EXIT_CODE=$?
+exit $EXIT_CODE

--- a/frameworks/eBPF-USDT/labels.sh
+++ b/frameworks/eBPF-USDT/labels.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+TITLE[0]="No instrumentation"
+TITLE[1]="Deactivated probe"
+TITLE[2]="No collection"
+TITLE[3]="Text file"
+TITLE[4]="Binary file"


### PR DESCRIPTION
This framework traces Java method calls using eBPF USDT. Unlike the existing bpftrace-java framework, it uses libbpf directly and a custom C++ userspace tracer, giving finer control over event collection and output format.
Requirements and how to run the benchmark are in the readme