### PR TITLE
Added RSECon26 logo

### DIFF
--- a/moobench-paper/paper.md
+++ b/moobench-paper/paper.md
@@ -28,6 +28,7 @@ affiliations:
    index: 4
 date: 12 March 2026
 bibliography: paper.bib
+rsecon26: accepted
 
 aas-doi: 10.3847/xxxxx <- update this with the DOI from AAS once you know it.
 ---


### PR DESCRIPTION
JOSS reviewers confirmed the acceptance of our paper. :)

Added the conference logo according to https://github.com/openjournals/joss-reviews/issues/10400#issuecomment-4716788438